### PR TITLE
[BUGFIX] Fix PHP 8 missing array key error

### DIFF
--- a/Classes/Controller/JobController.php
+++ b/Classes/Controller/JobController.php
@@ -175,19 +175,19 @@ class JobController extends ActionController
     public function initializeListAction()
     {
         $arguments = $this->request->getArguments();
-        if ((int)$arguments['filter']['categories'][0] === 0) {
+        if ((int)($arguments['filter']['categories'][0] ?? 1) === 0) {
             unset($arguments['filter']['categories']);
         }
-        if ((int)$arguments['filter']['regions'][0] === 0) {
+        if ((int)($arguments['filter']['regions'][0] ?? 1) === 0) {
             unset($arguments['filter']['regions']);
         }
-        if ((int)$arguments['filter']['sectors'][0] === 0) {
+        if ((int)($arguments['filter']['sectors'][0] ?? 1) === 0) {
             unset($arguments['filter']['sectors']);
         }
-        if ((int)$arguments['filter']['disciplines'][0] === 0) {
+        if ((int)($arguments['filter']['disciplines'][0] ?? 1) === 0) {
             unset($arguments['filter']['disciplines']);
         }
-        if ((int)$arguments['filter']['educations'][0] === 0) {
+        if ((int)($arguments['filter']['educations'][0] ?? 1) === 0) {
             unset($arguments['filter']['educations']);
         }
         $this->request->setArguments($arguments);


### PR DESCRIPTION
After installing on TYPO3 11 with PHP 8, we included all TypoScript templates.
Nevertheless an PHP 8 error occurs in frontend like:
PHP Warning: Undefined array key "filter" in /.../jobfair/Classes/Controller/JobController.php line 178